### PR TITLE
Change default poll interval/not exceed free tier

### DIFF
--- a/server.json
+++ b/server.json
@@ -7,8 +7,8 @@
     "install_cloud": "install_cloud.sh",
     "description": "Add weather data to the ISY994",
     "notice": "",
-    "shortPoll": "120",
-    "longPoll": "600",
+    "shortPoll": "200",
+    "longPoll": "900",
     "profile_version": "1.0.4",
     "credits": [ {
 	"title": "AERIS Weather: A node server for weather data",


### PR DESCRIPTION
Given it takes 2 API calls for current observations (observations and observations/summary), we need to relax the number of daily calls to be under 1000
These amounts bring you to 960 calls per day.